### PR TITLE
update version dependency on base 6.3

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection 'multi)
 
-(define deps '(("base" #:version "6.1.1")
+(define deps '(("base" #:version "6.3")
                "draw-lib"
                "srfi-lite-lib"
                "typed-racket-lib"


### PR DESCRIPTION
Because racket/struct was added in racket version 6.3.
