### PR TITLE
import cpointer? and ctype? using unsafe

### DIFF
--- a/typed/opengl/ffi-types.rkt
+++ b/typed/opengl/ffi-types.rkt
@@ -14,7 +14,9 @@
  F64Vector f64vector?
  )
 
-(require/typed
+(require typed/racket/unsafe) ; only for cpointer? and ctype?
+
+(unsafe-require/typed
  ffi/unsafe
  [#:opaque CPointer cpointer?]  ; includes Bytes and other things that can be used as cpointers
  [#:opaque CType ctype?]


### PR DESCRIPTION
To avoid using `any-wrap/c` on the inputs to the predicates, which would display a warning about not being able to wrap and protect opaque values (`#<cpointer>`).
