### PR TITLE
Add the license field to info.rkt

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -36,3 +36,4 @@
 (define pkg-authors '(ntoronto))
 
 (define version "1.2")
+(define license 'LGPL-3.0-only)


### PR DESCRIPTION
I use LGPL-3.0-only here. LGPL-3.0-or-later is another possibility, but I opt for the conservative one. Let me know if this should be changed.

As a side-effect, this should trigger a rebuild, which hopefully will fix the current build failure at
https://pkg-build.racket-lang.org/server/built/fail/pict3d.txt