### PR TITLE
remove dependency on unstable-lib

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -14,7 +14,6 @@
                "pict-lib" ; why?
                "profile-lib" ; for tests
                "pfds"
-               "unstable-lib"
                ))
 
 (define build-deps '("draw-doc"


### PR DESCRIPTION
`raco setup` didn't complain when I removed this dependency so I guess it isn't actually used.