### PR TITLE
Add on-resize event handler to big-bang3d

### DIFF
--- a/pict3d/scribblings/pict3d.scrbl
+++ b/pict3d/scribblings/pict3d.scrbl
@@ -2838,6 +2838,8 @@ There is currently no support for networked games.
                      [#:on-release on-release (-> S Natural Flonum String S) (λ (s n t k) s)]
                      [#:on-mouse on-mouse (-> S Natural Flonum Integer Integer String S)
                                  (λ (s n t x y e) s)]
+                     [#:on-resize on-resize (-> S Natural Flonum Integer Integer S)
+                                 (λ (s n t width height) s)]
                      [#:on-draw on-draw (-> S Natural Flonum Pict3D) (λ (s n t) empty-pict3d)]
                      )
          S]{
@@ -2850,7 +2852,7 @@ On startup, @racket[big-bang3d] begins to keep track of
  @item{The time @racket[t : Flonum], in milliseconds, initially set to @racket[0.0].}
 ]
 All callback functions---@racket[valid-state?], @racket[pause-state?], @racket[stop-state?], @racket[on-frame],
-@racket[on-key], @racket[on-release], @racket[on-mouse] and @racket[on-draw]---receive the current
+@racket[on-key], @racket[on-release], @racket[on-mouse], @racket[on-resize] and @racket[on-draw]---receive the current
 values of @racket[s], @racket[n] and @racket[t].
 
 There are two phases in running a 3D world program: initialization and frame loop.
@@ -2897,6 +2899,9 @@ that indicates what kind of event occurred.
 Values for @racket[e] are the symbols returned by the method @method[mouse-event% get-event-type]
 of @racket[mouse-event%], converted to strings, unless the symbol is @racket['motion].
 In that case, @racket[e] is @racket["drag"] if a mouse button is pressed; otherwise @racket["move"].
+
+Resize events are handled by computing @racket[(on-resize s n t width height)] to yield a new state @racket[s].
+The values @racket[width] and @racket[width] are the window's new width and height, in pixels.
 
 After every state update, the frame loop
 @itemlist[#:style 'ordered

--- a/pict3d/universe.rkt
+++ b/pict3d/universe.rkt
@@ -24,6 +24,7 @@
   (world-state-key world-state frame time code)
   (world-state-release world-state frame time code)
   (world-state-mouse world-state frame time x y code)
+  (world-state-resize world-state frame time width height)
   (world-state-draw world-state frame time)
   #:fallbacks [(define (world-state-valid? s n t) #t)
                (define (world-state-stop? s n t) #f)
@@ -31,6 +32,7 @@
                (define (world-state-key s n t k) s)
                (define (world-state-release s n t k) s)
                (define (world-state-mouse s n t x y e) s)
+               (define (world-state-resize s n t width height e) s)
                (define (world-state-draw s n t) empty-pict3d)])
 
 (define big-bang3d-state/c
@@ -44,6 +46,9 @@
                                       world-state?))]
    [world-state-mouse    (or/c #f (-> world-state? exact-nonnegative-integer? flonum?
                                       exact-integer? exact-integer? string?
+                                      world-state?))]
+   [world-state-resize    (or/c #f (-> world-state? exact-nonnegative-integer? flonum?
+                                      exact-integer? exact-integer?
                                       world-state?))]
    [world-state-draw     (or/c #f (-> world-state? exact-nonnegative-integer? flonum? pict3d?))]))
 
@@ -64,4 +69,5 @@
    #:on-key world-state-key
    #:on-release world-state-release
    #:on-mouse world-state-mouse
+   #:on-resize world-state-resize
    #:on-draw world-state-draw))


### PR DESCRIPTION
This adds an `#:on-resize` argument to `big-bang3d`, a callback function which is called with the new window dimensions every time they change (a passthrough for the `on-size` event).

Reasoning behind this (and please correct me if I'm missing something here) is that the coordinates given by mouse events become useless after the window is resized at all, as there is no way to get at the new window size. This seemed like the safest way to add access to the window size while maintaining backwards compatibility. Did this pretty quick, mainly using `on-mouse` as inspiration, so let me know if there are any changes I should make.

Been playing around with this library to make a game and love working with it so far! I've been challenging myself to stay within the confines of `big-bang3d` and see how far I can get, but I ran into this and couldn't see a way around it.